### PR TITLE
Support for setuptools-based installation.

### DIFF
--- a/bcam/main.py
+++ b/bcam/main.py
@@ -173,9 +173,13 @@ def run():
     ep.mw = mw
     mw.run()
 
-if __name__ == "__main__":
+def main():
     args = {"--log": {"is_set": util.NOT_SET, "has_option": util.NO_OPTION, "option": None}}
     util.parse_args(args)
     if args["--log"]["is_set"]:
         logging.getLogger("").setLevel(logging.DEBUG)
     run()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python2
+
+from setuptools import setup
+
+setup(
+    name='BCAM',
+    version='0.3.1',
+    description='CAM system for hobbyists',
+    long_description=open('README.md').read(),
+    author='Konstantin Kirik',
+    url='http://hobbycam.org/',
+    license='GPLv3+',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: X11 Applications :: GTK',
+        'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2 :: Only',
+        'Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)',
+    ],
+    install_requires=['dxfgrabber'], # Also requires pygtk>=2, but that can't
+                                     # be automatically installed by pip.
+    packages=['bcam'],
+    entry_points={'gui_scripts': ['bcam = bcam.main:main']},
+)


### PR DESCRIPTION
Added a setup.py script that will allow for standard installation with pip.  Installs BCAM source as a package, and generates a script named "bcam" to run it.  This will allow BCAM to be [uploaded to PyPI](https://packaging.python.org/en/latest/distributing.html#uploading-your-project-to-pypi), though it may require a change to how Ubuntu packages are created.