### PR TITLE
Switch to absolute imports in all submodules.

### DIFF
--- a/bcam/calc_utils.py
+++ b/bcam/calc_utils.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+
 import math
 from logging import debug, info, warning, error, critical
-from util import dbgfname
+from bcam.util import dbgfname
 
 def rgb255_to_rgb1(rgb):
     return [rgb[0]/255.0, rgb[1]/255.0, rgb[2]/255.0]

--- a/bcam/elements.py
+++ b/bcam/elements.py
@@ -1,9 +1,12 @@
+from __future__ import absolute_import
+
 import math
-from calc_utils import AABB, CircleUtils, LineUtils, ArcUtils, PointUtils, vect_len, mk_vect
-from tool_operation import TOEnum
+from bcam.calc_utils import (AABB, CircleUtils, LineUtils, ArcUtils, PointUtils,
+                             vect_len, mk_vect)
+from bcam.tool_operation import TOEnum
 
 from logging import debug, info, warning, error, critical
-from util import dbgfname
+from bcam.util import dbgfname
 
 
 import json

--- a/bcam/events.py
+++ b/bcam/events.py
@@ -1,25 +1,27 @@
+from __future__ import absolute_import
+
 import pygtk
 pygtk.require('2.0')
 import gtk, gobject, cairo
 import sys
 import os
 
-from loader_dxf import DXFLoader
-from tool_operation import TOResult
-from tool_op_drill import TODrill
-from tool_op_exact_follow import TOExactFollow
-from tool_op_offset_follow import TOOffsetFollow
-from tool_op_pocketing import TOPocketing
-from calc_utils import AABB, OverlapEnum
-from path import Path
-from project import project
-from generalized_setting import TOSTypes
+from bcam.loader_dxf import DXFLoader
+from bcam.tool_operation import TOResult
+from bcam.tool_op_drill import TODrill
+from bcam.tool_op_exact_follow import TOExactFollow
+from bcam.tool_op_offset_follow import TOOffsetFollow
+from bcam.tool_op_pocketing import TOPocketing
+from bcam.calc_utils import AABB, OverlapEnum
+from bcam.path import Path
+from bcam.project import project
+from bcam.generalized_setting import TOSTypes
 
 from logging import debug, info, warning, error, critical
-from util import dbgfname
+from bcam.util import dbgfname
 
-from singleton import Singleton
-from state import State
+from bcam.singleton import Singleton
+from bcam.state import State
 
 class EVEnum:
     load_click = "load_click"

--- a/bcam/generalized_setting.py
+++ b/bcam/generalized_setting.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 class TOSTypes:
     button = "button"
     float = "float"

--- a/bcam/loader.py
+++ b/bcam/loader.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 class SourceLoader(object):
     # should return list of paths
     def load(self, path):

--- a/bcam/loader_dxf.py
+++ b/bcam/loader_dxf.py
@@ -1,10 +1,12 @@
-import loader
-from calc_utils import rgb255_to_rgb1
-from path import ELine, EArc, ECircle, EPoint, Path
-from singleton import Singleton
+from __future__ import absolute_import
+
+from bcam import loader
+from bcam.calc_utils import rgb255_to_rgb1
+from bcam.path import ELine, EArc, ECircle, EPoint, Path
+from bcam.singleton import Singleton
 
 from logging import debug, info, warning, error, critical
-from util import dbgfname
+from bcam.util import dbgfname
 
 import dxfgrabber
 

--- a/bcam/main.py
+++ b/bcam/main.py
@@ -1,7 +1,9 @@
+from __future__ import absolute_import
+
 from logging import debug, info, warning, error, critical
 import logging
-from util import dbgfname
-import util
+from bcam.util import dbgfname
+from bcam import util
 
 logging.basicConfig(level=logging.WARNING)
 
@@ -9,11 +11,10 @@ import pygtk
 pygtk.require('2.0')
 import gtk, gobject, cairo
 import sys
-from events import EVEnum, EventProcessor, ee, ep
-from main_window import MainWindow
-from singleton import Singleton
-import project
-import state
+from bcam.events import EVEnum, EventProcessor, ee, ep
+from bcam.main_window import MainWindow
+from bcam.singleton import Singleton
+from bcam import project, state
 
 class Screen(gtk.DrawingArea):
 

--- a/bcam/main_window.py
+++ b/bcam/main_window.py
@@ -1,14 +1,16 @@
 #-*- encoding: utf-8 -*-
+from __future__ import absolute_import
+
 import pygtk
 pygtk.require('2.0')
 import gtk, gobject, cairo
 import sys
-from events import EVEnum, EventProcessor, ee, ep
-from singleton import Singleton
-from generalized_setting import TOSTypes
+from bcam.events import EVEnum, EventProcessor, ee, ep
+from bcam.singleton import Singleton
+from bcam.generalized_setting import TOSTypes
 
 from logging import debug, info, warning, error, critical
-from util import dbgfname
+from bcam.util import dbgfname
 
 
 class MainWindow(object):

--- a/bcam/path.py
+++ b/bcam/path.py
@@ -1,9 +1,11 @@
-from elements import *
-from calc_utils import pt_to_pt_dist
-from tool_operation import TOEnum
+from __future__ import absolute_import
+
+from bcam.elements import *
+from bcam.calc_utils import pt_to_pt_dist
+from bcam.tool_operation import TOEnum
 
 from logging import debug, info, warning, error, critical
-from util import dbgfname
+from bcam.util import dbgfname
 
 
 import json

--- a/bcam/postprocessor.py
+++ b/bcam/postprocessor.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
+
 from logging import debug, info, warning, error, critical
-from util import dbgfname
+from bcam.util import dbgfname
 
 class Postprocessor:
     def __init__(self):

--- a/bcam/pp_grbl.py
+++ b/bcam/pp_grbl.py
@@ -1,4 +1,6 @@
-from postprocessor import Postprocessor
+from __future__ import absolute_import
+
+from bcam.postprocessor import Postprocessor
 
 class PPGRBL:
     def __init__(self):

--- a/bcam/project.py
+++ b/bcam/project.py
@@ -1,10 +1,12 @@
-from path import Path
-from state import State
-import state
-from singleton import Singleton
+from __future__ import absolute_import
+
+from bcam.path import Path
+from bcam.state import State
+from bcam import state
+from bcam.singleton import Singleton
 
 from logging import debug, info, warning, error, critical
-from util import dbgfname
+from bcam.util import dbgfname
 
 import os
 import json
@@ -39,7 +41,7 @@ class Project(object):
 
     def load(self, project_path):
         dbgfname()
-        from events import ep, ee
+        from bcam.events import ep, ee
         #global state
 
         debug("  loading project from "+str(project_path))

--- a/bcam/settings.py
+++ b/bcam/settings.py
@@ -1,6 +1,8 @@
-from tool import Tool, ToolType
-from generalized_setting import TOSetting
-from pp_grbl import PPGRBL
+from __future__ import absolute_import
+
+from bcam.tool import Tool, ToolType
+from bcam.generalized_setting import TOSetting
+from bcam.pp_grbl import PPGRBL
 
 class LineType:
     def __init__(self, lw=None, selected_lw=None, color=None, selected_color=None, name=None, data=None):

--- a/bcam/singleton.py
+++ b/bcam/singleton.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 class Singleton(type):
     _instances = {}
     def __call__(cls, *args, **kwargs):

--- a/bcam/state.py
+++ b/bcam/state.py
@@ -1,8 +1,10 @@
-from settings import Settings
-from singleton import Singleton
+from __future__ import absolute_import
+
+from bcam.settings import Settings
+from bcam.singleton import Singleton
 
 from logging import debug, info, warning, error, critical
-from util import dbgfname
+from bcam.util import dbgfname
 
 class State:
     def __init__(self, data=None):
@@ -98,11 +100,11 @@ class State:
 
     def deserialize(self, data):
         dbgfname()
-        from path import Path
-        from tool_op_exact_follow import TOExactFollow
-        from tool_op_offset_follow import TOOffsetFollow
-        from tool_op_drill import TODrill
-        from tool_op_pocketing import TOPocketing
+        from bcam.path import Path
+        from bcam.tool_op_exact_follow import TOExactFollow
+        from bcam.tool_op_offset_follow import TOOffsetFollow
+        from bcam.tool_op_drill import TODrill
+        from bcam.tool_op_pocketing import TOPocketing
 
         self.__screen_offset = data["screen_offset"]
         self.__base_offset = data["base_offset"]

--- a/bcam/tool.py
+++ b/bcam/tool.py
@@ -1,4 +1,6 @@
-from generalized_setting import TOSetting
+from __future__ import absolute_import
+
+from bcam.generalized_setting import TOSetting
 
 class ToolType:
     cylinder = "cylinder"

--- a/bcam/tool_abstract_follow.py
+++ b/bcam/tool_abstract_follow.py
@@ -1,8 +1,10 @@
-from tool_operation import ToolOperation
-from singleton import Singleton
+from __future__ import absolute_import
+
+from bcam.tool_operation import ToolOperation
+from bcam.singleton import Singleton
 
 from logging import debug, info, warning, error, critical
-from util import dbgfname
+from bcam.util import dbgfname
 
 import cairo
 

--- a/bcam/tool_op_drill.py
+++ b/bcam/tool_op_drill.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+
 import math
-from tool_operation import ToolOperation, TOEnum
-from generalized_setting import TOSetting
+from bcam.tool_operation import ToolOperation, TOEnum
+from bcam.generalized_setting import TOSetting
 
 import json
 

--- a/bcam/tool_op_exact_follow.py
+++ b/bcam/tool_op_exact_follow.py
@@ -1,7 +1,9 @@
+from __future__ import absolute_import
+
 import math
-from tool_operation import ToolOperation, TOEnum
-from tool_abstract_follow import TOAbstractFollow
-from generalized_setting import TOSetting
+from bcam.tool_operation import ToolOperation, TOEnum
+from bcam.tool_abstract_follow import TOAbstractFollow
+from bcam.generalized_setting import TOSetting
 
 import cairo
 import json

--- a/bcam/tool_op_offset_follow.py
+++ b/bcam/tool_op_offset_follow.py
@@ -1,13 +1,16 @@
+from __future__ import absolute_import
+
 import math
-from tool_operation import ToolOperation, TOEnum
-from tool_abstract_follow import TOAbstractFollow
-from generalized_setting import TOSetting
-from calc_utils import find_vect_normal, mk_vect, normalize, vect_sum, vect_len, scale_vect, pt_to_pt_dist
-from elements import ELine, EArc, ECircle
-from singleton import Singleton
+from bcam.tool_operation import ToolOperation, TOEnum
+from bcam.tool_abstract_follow import TOAbstractFollow
+from bcam.generalized_setting import TOSetting
+from bcam.calc_utils import (find_vect_normal, mk_vect, normalize, vect_sum,
+                             vect_len, scale_vect, pt_to_pt_dist)
+from bcam.elements import ELine, EArc, ECircle
+from bcam.singleton import Singleton
 
 from logging import debug, info, warning, error, critical
-from util import dbgfname
+from bcam.util import dbgfname
 
 
 import cairo

--- a/bcam/tool_op_pocketing.py
+++ b/bcam/tool_op_pocketing.py
@@ -1,13 +1,17 @@
+from __future__ import absolute_import
+
 import math
-from tool_operation import ToolOperation, TOEnum, TOResult
-from tool_abstract_follow import TOAbstractFollow
-from generalized_setting import TOSetting, TOSTypes
-from calc_utils import find_vect_normal, mk_vect, normalize, vect_sum, vect_len, linearized_path_aabb, find_center_of_mass, sign, LineUtils
-from elements import ELine, EArc, EPoint
-from singleton import Singleton
+from bcam.tool_operation import ToolOperation, TOEnum, TOResult
+from bcam.tool_abstract_follow import TOAbstractFollow
+from bcam.generalized_setting import TOSetting, TOSTypes
+from bcam.calc_utils import (find_vect_normal, mk_vect, normalize, vect_sum,
+                             vect_len, linearized_path_aabb,
+                             find_center_of_mass, sign, LineUtils)
+from bcam.elements import ELine, EArc, EPoint
+from bcam.singleton import Singleton
 
 from logging import debug, info, warning, error, critical
-from util import dbgfname
+from bcam.util import dbgfname
 
 import json
 import cairo

--- a/bcam/tool_operation.py
+++ b/bcam/tool_operation.py
@@ -1,4 +1,6 @@
-from tool import Tool
+from __future__ import absolute_import
+
+from bcam.tool import Tool
 
 class TOEnum:
     drill = "drill"

--- a/bcam/util.py
+++ b/bcam/util.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from logging import debug, info, warning, error, critical
 import traceback
 import sys


### PR DESCRIPTION
This ensures that BCAM won't inadvertently shadow any other installed packages or modules.  It's also a prerequisite for porting to Python 3 (though there are many other requirements for that too).