### PR TITLE
Switch print statements to print function.

### DIFF
--- a/bcam/calc_utils.py
+++ b/bcam/calc_utils.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import math
 from logging import debug, info, warning, error, critical
@@ -391,15 +391,12 @@ class LineUtils(object):
         miny = min(self.start[1], self.end[1])
         maxy = max(self.start[1], self.end[1])
 
-        #print "s:", (minx, miny), "e:", (maxx, maxy)
-
         x_intersects = False
         y_intersects = False
 
         if abs(minx-maxx)<0.001:
             if abs(x_i-minx)<0.001:
                 x_intersects = True
-                #print "dx=0"
             else:
                 return False
         elif x_i>=minx and x_i<=maxx:
@@ -408,7 +405,6 @@ class LineUtils(object):
         if abs(miny-maxy)<0.001:
             if abs(y_i-miny)<0.001:
                 y_intersects = True
-                #print "dy=0"
             else:
                 return False
         elif y_i>=miny and y_i<=maxy:
@@ -422,9 +418,7 @@ class LineUtils(object):
     def find_intersection(self, other_element):
         #debug("In LineUtils.find_intersection")
         oe = other_element
-        #print oe
         if other_element.__class__.__name__ == "LineUtils":
-            #print "line to line"
             # line to line intersection
             ms, me = self.start, self.end
 
@@ -440,27 +434,18 @@ class LineUtils(object):
             det = float(ma*ob - oa*mb)
             if det == 0:
                 # lines are parallel
-                #print "parallel"
                 return None
             else:
                 x_i = (ob*mc-mb*oc)/det
                 y_i = (ma*oc-oa*mc)/det
-                #print "int:", x_i, y_i
                 if self.check_if_pt_belongs((x_i, y_i)):
-                    #print "on self"
                     if oe.check_if_pt_belongs((x_i, y_i)):
-                        #print "on oe"
                         return [x_i, y_i]
                     else:
-                        #print "not on oe"
-                        #print "int:", x_i, y_i
-                        #print "oe:", oe.start, oe.end
                         pass
                 else:
                     pass
-                    #print "not on self"
         elif other_element.__class__.__name__ == "ArcUtils":
-            #print "arc to line"
             return oe.find_intersection(self)
         else:
             debug("  Not calc util:", other_element.__class__.__name__)
@@ -484,12 +469,12 @@ if __name__=="__main__":
     au = ArcUtils((0, 0), 1, -10*math.pi/180.0, 300*math.pi/180.0)
     
     angle = 90
-    print "checking angle", angle, au.check_angle_in_range(angle*math.pi/180.0)
+    print("checking angle", angle, au.check_angle_in_range(angle*math.pi/180))
     angle = 190
-    print "checking angle", angle, au.check_angle_in_range(angle*math.pi/180.0)
+    print("checking angle", angle, au.check_angle_in_range(angle*math.pi/180))
     angle = -15
-    print "checking angle", angle, au.check_angle_in_range(angle*math.pi/180.0)
+    print("checking angle", angle, au.check_angle_in_range(angle*math.pi/180))
     angle = 290
-    print "checking angle", angle, au.check_angle_in_range(angle*math.pi/180.0)
+    print("checking angle", angle, au.check_angle_in_range(angle*math.pi/180))
     angle = 301
-    print "checking angle", angle, au.check_angle_in_range(angle*math.pi/180.0)
+    print("checking angle", angle, au.check_angle_in_range(angle*math.pi/180))

--- a/bcam/elements.py
+++ b/bcam/elements.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import math
 from bcam.calc_utils import (AABB, CircleUtils, LineUtils, ArcUtils, PointUtils,

--- a/bcam/events.py
+++ b/bcam/events.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import pygtk
 pygtk.require('2.0')

--- a/bcam/generalized_setting.py
+++ b/bcam/generalized_setting.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 class TOSTypes(object):
     button = "button"

--- a/bcam/loader.py
+++ b/bcam/loader.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 class SourceLoader(object):
     # should return list of paths

--- a/bcam/loader_dxf.py
+++ b/bcam/loader_dxf.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from bcam import loader
 from bcam.calc_utils import rgb255_to_rgb1, transform_pt
@@ -65,11 +65,9 @@ class DXFLoader(loader.SourceLoader):
 
         color = rgb255_to_rgb1(dxfgrabber.color.TrueColor.from_aci(color).rgb())
         if e.dxftype == DXFEnum.line:
-            #print "line"
             el = self.__mk_line(e.start, e.end, offset, color, rotation, scale)
             p.add_element(el)
         elif e.dxftype == DXFEnum.arc:
-            #print "arc"
             center = [0,0]
             startangle = e.startangle
             endangle = e.endangle
@@ -92,7 +90,6 @@ class DXFLoader(loader.SourceLoader):
             el = EArc(tuple(center[:2]), radius, startangle, endangle, Singleton.state.settings.get_def_lt(), color=color)
             p.add_element(el)
         elif e.dxftype == DXFEnum.circle:
-            #print "circle"
             center = [0,0]
 
             if ((rotation != None) and (rotation != 0)):
@@ -112,7 +109,6 @@ class DXFLoader(loader.SourceLoader):
             el = ECircle(tuple(center[:2]), radius, Singleton.state.settings.get_def_lt(), color)
             p.add_element(el)
         elif e.dxftype == DXFEnum.point:
-            #print "circle"
             center = [0,0]
 
             if ((rotation != None) and (rotation != 0)):

--- a/bcam/main.py
+++ b/bcam/main.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from logging import debug, info, warning, error, critical
 import logging

--- a/bcam/main_window.py
+++ b/bcam/main_window.py
@@ -1,5 +1,5 @@
 #-*- encoding: utf-8 -*-
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import pygtk
 pygtk.require('2.0')

--- a/bcam/path.py
+++ b/bcam/path.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from bcam.elements import *
 from bcam.calc_utils import pt_to_pt_dist
@@ -76,7 +76,6 @@ class Path(Element):
         min_dist = pt_to_pt_dist(available[0].start, current.end)
         min_dist_id = 0
         min_order = {"turnaround": False, "offset": 1}
-        #print "current:", current
         for i, e in enumerate(available):
             orders = []
             dists = []
@@ -91,12 +90,10 @@ class Path(Element):
                 dists.append(pt_to_pt_dist(e.start, current.start))
                 orders.append({"turnaround": True, "offset": -1})
             md = min(dists)
-            #print dists
             if md<min_dist:
                 min_dist = md
                 min_dist_id = i
                 min_order = orders[dists.index(md)]
-                #print "md, i:", md, i
         return min_dist, min_dist_id, min_order
 
     def __append_element(self, min_dist_id, min_order, available, ordered_elements, ce):
@@ -156,21 +153,15 @@ class Path(Element):
                 break
             cont = False
             current = (ordered_elements[-1], ordered_elements[0])
-            #print "ordered_elements:", ordered_elements
-            #print "current:", current
-            #print "available:", available
             min_dist, min_dist_id, min_order = self.__find_adjacent_element(current[0], available)
-            #print "md, mdi, mo:", min_dist, min_dist_id, min_order
             if (min_dist<0.001):
                 
                 self.__append_element(min_dist_id, min_order, available, ordered_elements, ce)
-                #print "append, turnaround:", min_order["turnaround"]
                 cont = True
             if not cont:
                 min_dist, min_dist_id, min_order = self.__find_adjacent_element(current[1], available, False)
                 if (min_dist<0.001):
                     self.__append_element(min_dist_id, min_order, available, ordered_elements, ce)
-                    #print "prepend, turnaround:", min_order["turnaround"]
                     cont = True
 
             if not cont:

--- a/bcam/postprocessor.py
+++ b/bcam/postprocessor.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from logging import debug, info, warning, error, critical
 from bcam.util import dbgfname

--- a/bcam/pp_grbl.py
+++ b/bcam/pp_grbl.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from bcam.postprocessor import Postprocessor
 

--- a/bcam/project.py
+++ b/bcam/project.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from bcam.path import Path
 from bcam.state import State
@@ -50,7 +50,6 @@ class Project(object):
         f.close()
         parsed_json = json.loads(data)
         self.steps = []
-        #print "json:", parsed_json
         if parsed_json["format_version"] == 2:
             step = Step(data=parsed_json["step"])
             self.steps.append(step)

--- a/bcam/settings.py
+++ b/bcam/settings.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from bcam.tool import Tool, ToolType
 from bcam.generalized_setting import TOSetting

--- a/bcam/singleton.py
+++ b/bcam/singleton.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 class Singleton(type):
     _instances = {}

--- a/bcam/state.py
+++ b/bcam/state.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from bcam.settings import Settings
 from bcam.singleton import Singleton

--- a/bcam/tool.py
+++ b/bcam/tool.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from bcam.generalized_setting import TOSetting
 

--- a/bcam/tool_abstract_follow.py
+++ b/bcam/tool_abstract_follow.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from bcam.tool_operation import ToolOperation
 from bcam.singleton import Singleton

--- a/bcam/tool_op_drill.py
+++ b/bcam/tool_op_drill.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import math
 from bcam.tool_operation import ToolOperation, TOEnum

--- a/bcam/tool_op_exact_follow.py
+++ b/bcam/tool_op_exact_follow.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import math
 from bcam.tool_operation import ToolOperation, TOEnum

--- a/bcam/tool_op_offset_follow.py
+++ b/bcam/tool_op_offset_follow.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import math
 from bcam.tool_operation import ToolOperation, TOEnum

--- a/bcam/tool_op_pocketing.py
+++ b/bcam/tool_op_pocketing.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 import math
 from bcam.tool_operation import ToolOperation, TOEnum, TOResult

--- a/bcam/tool_operation.py
+++ b/bcam/tool_operation.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from bcam.tool import Tool
 

--- a/bcam/util.py
+++ b/bcam/util.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 from logging import debug, info, warning, error, critical
 import traceback
@@ -31,8 +31,9 @@ def parse_args(args):
                 try:
                     args[arg]["option"] = sys.argv[i+1]
                 except:
-                    print "expected option for argument", arg, ", but it doesnt exist"
-                    print usage
+                    print("expected option for argument", arg,
+                          ", but it doesnt exist")
+                    print(usage)
                     exit()
                 else:
                     args[arg]["is_set"] = SET


### PR DESCRIPTION
All modules gained the `print_function` future import, and the few print statements were replaced with equivalent calls to the function.  A number of commented-out print statements were removed; uncommenting them would have resulted in an error, but commented code should generally not be left in anyways.  If those commented-out lines were being used for debugging, I would instead suggest replacing them with the [`logging` module](https://docs.python.org/2/library/logging.html).